### PR TITLE
Export remote-host procedure

### DIFF
--- a/remote-shell-doc/remote-shell.scrbl
+++ b/remote-shell-doc/remote-shell.scrbl
@@ -113,6 +113,10 @@ Combines @racket[remote] and @racket[path] to form an argument for
 Runs a simple command at @racket[remote] to check that it receives
 connections, trying up to @racket[tries] times.}
 
+@defproc[(remote-host [remote remote?]) string?]{
+  Gets the hostname that the remote is set to use in string form.
+
+@history[#:added "6.12"]}
 
 @; ----------------------------------------
 

--- a/remote-shell-lib/ssh.rkt
+++ b/remote-shell-lib/ssh.rkt
@@ -31,7 +31,9 @@
                                       (#:tries exact-nonnegative-integer?)
                                       . ->* .
                                       void?)]
-          [at-remote (remote? path-string? . -> . string?)]))
+          [at-remote (remote? path-string? . -> . string?)]
+
+          [remote-host ((remote?) . ->* . string?)]))
 
 (struct remote (host user timeout remote-tunnels env key)
   #:constructor-name make-remote)

--- a/remote-shell-lib/ssh.rkt
+++ b/remote-shell-lib/ssh.rkt
@@ -33,7 +33,7 @@
                                       void?)]
           [at-remote (remote? path-string? . -> . string?)]
 
-          [remote-host ((remote?) . ->* . string?)]))
+          [remote-host (remote? . -> . string?)]))
 
 (struct remote (host user timeout remote-tunnels env key)
   #:constructor-name make-remote)


### PR DESCRIPTION
I'm working on an automation library (similar to http://www.fabfile.org/) and found it useful to be able to print out the current remote's hostname if I have a remote struct. All this does is export the remote-host procedure.