### PR TITLE
Add import-vbox-vm and vagrant module

### DIFF
--- a/remote-shell-doc/remote-shell.scrbl
+++ b/remote-shell-doc/remote-shell.scrbl
@@ -1,6 +1,7 @@
 #lang scribble/manual
 @(require (for-label racket/base
                      racket/contract
+                     racket/string
                      remote-shell/ssh
                      remote-shell/vbox))
 
@@ -209,3 +210,21 @@ Returns the UUID of @racket[snapshot-name] for the virtual machine
 @racket[name].
 
 @history[#:added "1.1"]}
+
+@defproc[(import-vbox-vm [path path-string?]
+                         [#:name name (or/c false/c non-empty-string?) #f]
+                         [#:cpus cpus (or/c false/c exact-positive-integer?) #f]
+                         [#:memory memory (or/c false/c exact-positive-integer?) #f]) void?]{
+
+Imports a VirtualBox VM from the OVF file at @racket[path].
+
+When provided, @racket[name] specifies what the VM's alias (as seen in
+the GUI and in the output of commands like @exec{VBoxManage list vms})
+ought to be.
+
+The @racket[cpus] argument can be used to override the number of
+processors the VM has access to.
+
+The @racket[memory] argument can be used to override the amount of RAM
+(in MB) the VM has access to.
+}


### PR DESCRIPTION
Related to https://github.com/racket/pkg-build/pull/6.

If this seems reasonable/acceptable, I'll make a follow-up PR to document the `vagrant` module and then update `pkg-build` to drop the dependency on Vagrant.

```racket
(create-vbox-vm/vagrant-box "ubuntu/bionic64" "tmp")
```

^ downloads the last published Ubuntu 18.04 image from the official Vagrant host into a folder called `tmp` and then imports the VM into VirtualBox.
