### PR TITLE
Fix 'output mode

### DIFF
--- a/remote-shell-doc/remote-shell.scrbl
+++ b/remote-shell-doc/remote-shell.scrbl
@@ -104,7 +104,7 @@ If @racket[mode] is @racket['error], then the result is
 with an connection error, an error exit code, or by timing out. If
 @racket[mode] is @racket['result], then the result is @racket[#t] for
 success or @racket[#f] for failure. If @racket[mode] is
-@racket['cons], then the result is a pair containing whether the
+@racket['output], then the result is a pair containing whether the
 command succeeded and a byte string for the command's output
 (including error output).
 

--- a/remote-shell-lib/ssh.rkt
+++ b/remote-shell-lib/ssh.rkt
@@ -93,7 +93,7 @@
      (remote-shell remote)
      (list (apply ~a args))))
 
-  (define saved (and (or failure-dest success-dest)
+  (define saved (and (or (equal? mode 'output) failure-dest success-dest)
                      (open-output-bytes)))
   (define (tee o1 o2)
     (cond


### PR DESCRIPTION
- Fixes documentation which mistakenly calls it `cons`
- Patch ssh.rkt to save output buffer when mode is `'output`